### PR TITLE
Redirects spezi.health to spezi.stanford.edu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://spezi.stanford.edu/</title>
+<meta http-equiv="refresh" content="0; URL=https://spezi.stanford.edu/">
+<link rel="canonical" href="https://spezi.stanford.edu/">


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# *Name of the PR*

## :recycle: Current situation & Problem
The official Spezi website is at spezi.stanford.edu, however, spezi.health, which is designed to be used as a domain for hosting projects and their documentation via Github, is pointed to this Github organization. This causes confusion because spezi.health has no content.

## :bulb: Proposed solution
Sets up a redirect to send visitors to the official Spezi website, while still being able to use spezi.health as the root domain for projects hosted on Github.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
