### PR TITLE
Create a redirect to the Phoenix Survey Builder

### DIFF
--- a/phoenix/index.html
+++ b/phoenix/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://stanfordbdhg.github.io/phoenix</title>
+<meta http-equiv="refresh" content="0; URL=https://stanfordbdhg.github.io/phoenix">
+<link rel="canonical" href="https://stanfordbdhg.github.io/phoenix">


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Create a redirect to the Phoenix Survey Builder

## :recycle: Current situation & Problem
We want to create an easy to remember url to the Phoenix Survey Builder under the spezi.health domain.

## :bulb: Proposed solution
Creates a redirect from https://spezi.health/phoenix to https://stanfordbdhg.github.io/phoenix.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
